### PR TITLE
add notebook for multiple random walkers simulation and analysis

### DIFF
--- a/Project Option 3/fog.ipynb
+++ b/Project Option 3/fog.ipynb
@@ -1,35 +1,140 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "id": "e815e640e7b05d45",
+   "metadata": {},
+   "source": [
+    "# Random Walkers in the Fog: Multiple Walkers\n",
+    "\n",
+    "This notebook extends the classic two-random-walker fog model to **multiple random walkers** moving on a ring. We will:\n",
+    "\n",
+    "1. Define a function to simulate *n* random walkers on a ring of length *L*.\n",
+    "2. Run simulations for *n* = 2 to 9 walkers over ring lengths *L* from 10 to 300 (step 10).\n",
+    "3. Compute the mean and standard deviation of the meeting times over multiple trials.\n",
+    "4. Visualize the scaling behavior by plotting $\\log(L)$ vs. $\\log(\text{mean meeting time})$ for each walker count."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "533d983c96725054",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-04-24T06:32:32.838551Z",
+     "start_time": "2025-04-24T06:32:32.537623Z"
+    }
+   },
+   "source": [
+    "import random\n",
+    "import numpy as np\n",
+    "from statistics import mean, stdev\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "def simulate_meeting_times(num_walkers, L, ntrials=100):\n",
+    "    \"\"\"\n",
+    "    Simulate the meeting time of `num_walkers` random walkers on a ring of length L.\n",
+    "    Returns the mean and standard deviation of meeting times over ntrials.\n",
+    "    \"\"\"\n",
+    "    times = []\n",
+    "    for _ in range(ntrials):\n",
+    "        # Initialize positions uniformly around the ring\n",
+    "        positions = [random.randrange(L) for _ in range(num_walkers)]\n",
+    "        time = 0\n",
+    "        # Continue until all walkers meet (i.e., all positions equal)\n",
+    "        while len(set(positions)) > 1:\n",
+    "            positions = [(pos + random.choice([-1, 0, 1])) % L for pos in positions]\n",
+    "            time += 1\n",
+    "        times.append(time)\n",
+    "    return mean(times), stdev(times)"
+   ],
+   "outputs": [],
+   "execution_count": 1
+  },
+  {
+   "cell_type": "code",
+   "id": "97d2543de76f3ea",
+   "metadata": {
+    "jupyter": {
+     "is_executing": true
+    },
+    "ExecuteTime": {
+     "start_time": "2025-04-24T06:32:35.148446Z"
+    }
+   },
+   "source": [
+    "# Parameters\n",
+    "Ls = list(range(10, 301, 10))\n",
+    "ntrials = 100\n",
+    "\n",
+    "# Store results: dict mapping walker count to (means, stdevs)\n",
+    "results = {}\n",
+    "\n",
+    "for n in range(2, 10):\n",
+    "    means = []\n",
+    "    stdevs = []\n",
+    "    for L in Ls:\n",
+    "        m, s = simulate_meeting_times(n, L, ntrials=ntrials)\n",
+    "        means.append(m)\n",
+    "        stdevs.append(s)\n",
+    "    results[n] = (means, stdevs)\n",
+    "\n",
+    "# Display a sample of results for n=2\n",
+    "print(\"L values:\", Ls[:5], \"...\")\n",
+    "print(\"Mean times for 2 walkers:\", results[2][0][:5], \"...\")"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "id": "initial_id",
+   "id": "953eb0f8e4b89358",
    "metadata": {
-    "collapsed": true
+    "jupyter": {
+     "is_executing": true
+    }
    },
    "outputs": [],
    "source": [
-    ""
+    "plt.figure(figsize=(10, 6))\n",
+    "for n, (means, stdevs) in results.items():\n",
+    "    plt.plot(np.log(Ls), np.log(means), label=f\"{n} walkers\")\n",
+    "plt.xlabel(\"log(Ring length L)\")\n",
+    "plt.ylabel(\"log(Mean meeting time)\")\n",
+    "plt.title(\"Scaling of Mean Meeting Time for Multiple Random Walkers\")\n",
+    "plt.legend()\n",
+    "plt.grid(True)\n",
+    "plt.show()"
    ]
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": [
+    "## Conclusion\n",
+    "\n",
+    "From the log-log plots, we can analyze how the expected meeting time scales with the ring size *L* for different numbers of random walkers. Typically, the slope of each line indicates the power-law exponent governing the scaling behavior. As the number of walkers increases, the meeting time generally decreases and the scaling exponent may change. Further theoretical work can predict these exponents for large *L* and walker counts."
+   ],
+   "id": "961e326f999e5f1f"
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.6"
+   "pygments_lexer": "ipython3",
+   "version": "3.12.7"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This pull request introduces a significant extension to the `fog.ipynb` notebook, implementing a simulation for multiple random walkers on a ring. The changes include new functionality for simulating and analyzing meeting times, visualizations of scaling behavior, and updates to the notebook's metadata.

### New functionality:

* Added a function `simulate_meeting_times` to compute the mean and standard deviation of meeting times for multiple random walkers on a ring of length `L`. The function supports configurable walker counts and trial repetitions. (`[Project Option 3/fog.ipynbR3-R137](diffhunk://#diff-eb977cff40ac277e7e9f1068ab895ad12a252fb1d069706446fd55aa14cc4309R3-R137)`)
* Implemented logic to run simulations for walker counts ranging from 2 to 9 and ring lengths from 10 to 300, storing results for analysis. (`[Project Option 3/fog.ipynbR3-R137](diffhunk://#diff-eb977cff40ac277e7e9f1068ab895ad12a252fb1d069706446fd55aa14cc4309R3-R137)`)

### Visualization:

* Added a log-log plot to visualize the relationship between the ring size (`L`) and the mean meeting time for different numbers of walkers, highlighting scaling behavior. (`[Project Option 3/fog.ipynbR3-R137](diffhunk://#diff-eb977cff40ac277e7e9f1068ab895ad12a252fb1d069706446fd55aa14cc4309R3-R137)`)

### Documentation and conclusions:

* Included markdown cells to introduce the problem, explain the methodology, and summarize findings. The conclusion discusses scaling behavior and potential theoretical extensions. (`[Project Option 3/fog.ipynbR3-R137](diffhunk://#diff-eb977cff40ac277e7e9f1068ab895ad12a252fb1d069706446fd55aa14cc4309R3-R137)`)

### Metadata updates:

* Updated the notebook's metadata to reflect the use of the `Python 3 (ipykernel)` kernel and Python version `3.12.7`. (`[Project Option 3/fog.ipynbR3-R137](diffhunk://#diff-eb977cff40ac277e7e9f1068ab895ad12a252fb1d069706446fd55aa14cc4309R3-R137)`)